### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/a.py
+++ b/a.py
@@ -2,13 +2,13 @@
 # -*- coding: utf-8 -*-
 
 variable = "testing"
-print "das ist ein %s" % variable
-print "das ist ein %s" % variable
+print "das ist ein {0!s}".format(variable)
+print "das ist ein {0!s}".format(variable)
 exec(variable)
 eval(varialbe)
 eval(variable)
 eval("print variable")
-print "das %s" % "ist"
+print "das {0!s}".format("ist")
 eval("print variable")
 eval("print variable")
 

--- a/b.py
+++ b/b.py
@@ -2,13 +2,13 @@
 # -*- coding: utf-8 -*-
 
 variable = "testing"
-print "das ist ein %s" % variable
-print "das ist ein %s" % variable
+print "das ist ein {0!s}".format(variable)
+print "das ist ein {0!s}".format(variable)
 exec(variable)
 eval(varialbe)
 eval(variable)
 eval("print variable")
-print "das %s" % "ist"
+print "das {0!s}".format("ist")
 eval("print variable")
 eval("print variable")
 


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:vogelsgesang:qc-test?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:vogelsgesang:qc-test?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)
